### PR TITLE
Adds the rustup target add command to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 To build:
 
 ```
+rustup target add wasm32-unknown-unknown
 cargo build --target wasm32-unknown-unknown --release
 ```
 


### PR DESCRIPTION
The compiler gives an error when following the documentation. This adds the missing piece.
![image](https://github.com/wokwi/rust_chip_inverter/assets/16221324/b38a4b73-2a59-42f4-996d-4b128ab317f2)
